### PR TITLE
LSP 3.16 の セマンティックトークンをサポート

### DIFF
--- a/hsp3-analyzer-mini/vscode-ext/src/extension.ts
+++ b/hsp3-analyzer-mini/vscode-ext/src/extension.ts
@@ -11,6 +11,7 @@ import {
   LanguageClientOptions,
   ServerOptions,
 } from "vscode-languageclient"
+import { SemanticTokensFeature } from "vscode-languageclient/lib/semanticTokens.proposed"
 
 let client: LanguageClient
 
@@ -59,6 +60,7 @@ const startLspClient = (context: ExtensionContext) => {
     serverOptions,
     clientOptions
   )
+  client.registerFeature(new SemanticTokensFeature(client))
   client.start()
 }
 

--- a/hsp3-analyzer-mini/vscode-ext/src/semantic_highlight.ts
+++ b/hsp3-analyzer-mini/vscode-ext/src/semantic_highlight.ts
@@ -1,0 +1,17 @@
+
+import {
+  LanguageClient,
+  LanguageClientOptions,
+  ServerOptions,
+} from "vscode-languageclient"
+
+import { TextDocument, CancellationToken, } from "vscode"
+
+import { SemanticTokensFeature, DocumentSemanticsTokensSignature } from 'vscode-languageclient/lib/semanticTokens.proposed';
+
+// Workaround for https://github.com/microsoft/vscode-languageserver-node/issues/576
+export const provideDocumentSemanticTokens = async (document: TextDocument, token: CancellationToken, next: DocumentSemanticsTokensSignature) => {
+  const res = await next(document, token);
+  if (res === undefined) throw new Error('busy');
+  return res;
+}


### PR DESCRIPTION
変数、関数、型名などを LSP サーバ側で判断して色分けする機能。

HSP3 は構文に基づいて色分けするのが難しい言語なので価値が高い。

プロポーザル:

[Support semantic highlighting · Issue #18 · microsoft/language-server-protocol](https://github.com/microsoft/language-server-protocol/issues/18)

rust-analyzer での実装例:

https://github.com/rust-analyzer/rust-analyzer/blob/992e1256d05d1ec046e284e597b2932e50ccff49/editors/code/src/client.ts#L111

https://github.com/rust-analyzer/rust-analyzer/blob/992e1256d05d1ec046e284e597b2932e50ccff49/crates/rust-analyzer/src/main_loop/handlers.rs#L1075-L1103